### PR TITLE
Fix CRC checks on VerifyStream

### DIFF
--- a/util/python/alibabacloud_oss_util/verify_stream.py
+++ b/util/python/alibabacloud_oss_util/verify_stream.py
@@ -77,7 +77,14 @@ class VerifyStream(BaseStream):
         else:
             bres = res
 
-        if size <= self._file_size:
+        if size == sys.maxsize or size >= self.file_size:
+            self.crc.update(bres)
+            self.md5.update(bres)
+            self.ref['md5'] = base64.b64encode(self.md5.digest()).decode('utf-8')
+            self.ref['crc'] = self.crc.get_value()
+            return res
+
+        if self._file_size > 0:
             self.crc.update(bres)
             self.md5.update(bres)
         else:
@@ -90,13 +97,6 @@ class VerifyStream(BaseStream):
                 raise StopIteration
             else:
                 return res
-
-        if size == sys.maxsize or size >= self.file_size:
-            self.crc.update(bres)
-            self.md5.update(bres)
-            self.ref['md5'] = base64.b64encode(self.md5.digest()).decode('utf-8')
-            self.ref['crc'] = self.crc.get_value()
-            return res
 
         self._file_size -= len(bres)
         return res


### PR DESCRIPTION
Currently I am getting CrcNotMatched errors when I try to upload files. The CRC returned by the server is the correct CRC but the client is calculating an incorrect CRC.

With the current logic, the last chunk of the file will not be calculated into the CRC and MD5 hashes because the size of bytes left in the file is less than the read size.
```python
       if size <= self._file_size:
            self.crc.update(bres)
            self.md5.update(bres)
```

This patch will ensure the whole file is used to calculate the CRC and MD5 hashes.